### PR TITLE
fix: using dimensions from react-native-safe-area-context for consistency

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "react-native-builder-bob": "^0.40.6",
     "react-native-gesture-handler": "^2.25.0",
     "react-native-reanimated": "^3.17.4",
+    "react-native-safe-area-context": "^5.3.0",
     "release-it": "^17.10.0",
     "typescript": "^5.2.2",
     "zustand": "^5.0.3"
@@ -70,6 +71,7 @@
     "react-native": "*",
     "react-native-gesture-handler": ">=2.0.0",
     "react-native-reanimated": ">=3.0.0",
+    "react-native-safe-area-context": ">=5.0.0",
     "zustand": ">=5.0.0"
   },
   "workspaces": [

--- a/src/BottomSheetHost.tsx
+++ b/src/BottomSheetHost.tsx
@@ -4,7 +4,8 @@ import React, {
   useMemo,
   type PropsWithChildren,
 } from 'react';
-import { StyleSheet, useWindowDimensions, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
+import { useSafeAreaFrame } from 'react-native-safe-area-context';
 
 import { BottomSheetContext } from './BottomSheet.context';
 import { useBottomSheetStore } from './bottomSheet.store';
@@ -23,7 +24,7 @@ function BottomSheetHostComp({ Container = Fragment }: BottomSheetHostProps) {
     clearAll: store.clearAll,
   }));
 
-  const { width, height } = useWindowDimensions();
+  const { width, height } = useSafeAreaFrame();
   const { groupId } = useBottomSheetManagerContext();
 
   const filteredQueue = useMemo(

--- a/yarn.lock
+++ b/yarn.lock
@@ -11849,6 +11849,7 @@ __metadata:
     react-native-builder-bob: ^0.40.6
     react-native-gesture-handler: ^2.25.0
     react-native-reanimated: ^3.17.4
+    react-native-safe-area-context: ^5.3.0
     release-it: ^17.10.0
     typescript: ^5.2.2
     zustand: ^5.0.3
@@ -11858,6 +11859,7 @@ __metadata:
     react-native: "*"
     react-native-gesture-handler: ">=2.0.0"
     react-native-reanimated: ">=3.0.0"
+    react-native-safe-area-context: ">=5.0.0"
     zustand: ">=5.0.0"
   languageName: unknown
   linkType: soft
@@ -11939,6 +11941,16 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 8c812466c3a1d7d3576365f16c62183efd9651ae769849a40240a3f674131960e2380c8536232563dd0935a607696eb373abcece899ce4152bfdd711778e7cd7
+  languageName: node
+  linkType: hard
+
+"react-native-safe-area-context@npm:^5.3.0":
+  version: 5.5.2
+  resolution: "react-native-safe-area-context@npm:5.5.2"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 694e293b474b0738899c6e09da9f001d8087b382b5a40b8b227765c861a8137f0ff0209f1c9d8ae94337bc9c170eb114a9b897a8661b8181f48759a21baeb265
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description
The issue originates from `BottomSheetHost` and is related to how height is derived from the `useWindowDimensions` hook, combined with the behavior of `StyleSheet.absoluteFillObject`.

Currently, when a View has a fixed height and uses `absoluteFillObject`, it is positioned from the top, but the height is shorter than the actual screen height — resulting in a visible gap at the bottom.

This discrepancy is caused by differences between the values returned by `Dimensions.get('screen')` and `Dimensions.get('window')`. The `useWindowDimensions` hook returns the window height, whereas in my case, `Dimensions.get('screen').height` reflects the correct full screen height.

### Proposed Solution
Using dimensions from useSafeAreaFrame should give us correct height values.