### PR TITLE
fix: allowing backdropComponent to be overriden

### DIFF
--- a/src/BottomSheetManaged.tsx
+++ b/src/BottomSheetManaged.tsx
@@ -22,7 +22,14 @@ export const BottomSheetManaged = React.forwardRef<
   BottomSheetManagedProps
 >(
   (
-    { children, onAnimate, onClose, enablePanDownToClose = true, ...props },
+    {
+      children,
+      onAnimate,
+      onClose,
+      enablePanDownToClose = true,
+      backdropComponent,
+      ...props
+    },
     ref
   ) => {
     const { startClosing, finishClosing } = useBottomSheetStore.getState();
@@ -90,8 +97,8 @@ export const BottomSheetManaged = React.forwardRef<
         {...props}
         onClose={handleClose}
         onAnimate={handleOnAnimate}
+        backdropComponent={backdropComponent || renderBackdropComponent}
         enablePanDownToClose={enablePanDownToClose}
-        backdropComponent={renderBackdropComponent}
       >
         {children}
       </BottomSheetOriginal>


### PR DESCRIPTION
This pull request introduces a minor enhancement to the `BottomSheetManaged` component, making it possible to provide a custom backdrop component through props. If no custom backdrop is provided, the default one is used.

- **Component API enhancement:**
  - Added a new `backdropComponent` prop to `BottomSheetManaged`, allowing consumers to override the default backdrop if desired.
  - Updated the rendering logic to use the provided `backdropComponent` prop if available, falling back to the default `renderBackdropComponent` otherwise.