### PR TITLE
chore: sync lockfile with 0.13 peer range

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -12222,7 +12222,7 @@ __metadata:
     zustand: ^5.0.3
   peerDependencies:
     "@gorhom/bottom-sheet": ">=5.0.0"
-    "@swmansion/react-native-bottom-sheet": ">=0.13.0-next.0"
+    "@swmansion/react-native-bottom-sheet": ">=0.13.0-next.1"
     react: "*"
     react-native: "*"
     react-native-actions-sheet: ">=0.9.0"


### PR DESCRIPTION
Post-merge fix. PR #22 was squash-merged with `package.json` peer at `>=0.13.0-next.1` while `yarn.lock` still recorded `>=0.13.0-next.0`, which breaks `yarn install --immutable` on main. Regenerates the lockfile to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)