### PR TITLE
feat(swmansion): block dismiss gesture natively + expose preventDismiss

### DIFF
--- a/src/adapters/swmansion/SwmansionSheetAdapter.tsx
+++ b/src/adapters/swmansion/SwmansionSheetAdapter.tsx
@@ -18,7 +18,7 @@ import { useBottomSheetContext } from '../../useBottomSheetContext';
 
 // Loaded lazily so the main bundle never requires the native module unless
 // this adapter is actually imported (it ships as an optional peer dependency).
-const { BottomSheet } =
+const { BottomSheet, programmatic } =
   require('@swmansion/react-native-bottom-sheet') as typeof import('@swmansion/react-native-bottom-sheet');
 
 export { programmatic } from '@swmansion/react-native-bottom-sheet';
@@ -218,10 +218,21 @@ export const SwmansionSheetAdapter = React.forwardRef<
       onPositionChange?.(position);
     };
 
+    // When dismissal is blocked, mark the collapsed detent (index 0) as
+    // programmatic so the native sheet cannot be dragged down to it. This is the
+    // native equivalent of "prevent pan-to-close" — `close()` still collapses it
+    // via the controlled `index`. The JS re-snap in `handleNativeIndexChange`
+    // alone cannot block the native gesture.
+    const resolvedDetents = preventDismiss
+      ? detents.map((detent, detentIndex) =>
+          detentIndex === 0 ? programmatic(resolveDetentValue(detent)) : detent
+        )
+      : detents;
+
     return (
       <BottomSheet
         {...props}
-        detents={detents}
+        detents={resolvedDetents}
         animateIn={animateIn}
         scrimColor={scrimColor}
         // Managed by adapter (not overridable):

--- a/src/useBottomSheetContext.ts
+++ b/src/useBottomSheetContext.ts
@@ -1,5 +1,9 @@
 import { useMaybeBottomSheetContext } from './BottomSheet.context';
-import { useSheetParams, useStartClosing } from './bottomSheet.store';
+import {
+  useSheetParams,
+  useSheetPreventDismiss,
+  useStartClosing,
+} from './bottomSheet.store';
 import { requestClose } from './bottomSheetCoordinator';
 import type {
   BottomSheetPortalId,
@@ -9,6 +13,12 @@ import type {
 export interface UseBottomSheetContextReturn<TParams> {
   id: string;
   params: TParams;
+  /**
+   * Whether dismissal is currently blocked for this sheet (set via
+   * `useOnBeforeClose`). Adapters block user gestures when this is true; UI can
+   * read it to e.g. hide a grab handle.
+   */
+  preventDismiss: boolean;
   close: () => void;
   /**
    * Close the sheet, bypassing any onBeforeClose interceptor.
@@ -30,6 +40,7 @@ export function useBottomSheetContext<
 >(): UseBottomSheetContextReturn<BottomSheetPortalParams<T> | unknown> {
   const context = useMaybeBottomSheetContext();
   const params = useSheetParams(context?.id || '');
+  const preventDismiss = useSheetPreventDismiss(context?.id || '');
   const startClosing = useStartClosing();
 
   if (!context?.id) {
@@ -46,6 +57,7 @@ export function useBottomSheetContext<
   return {
     id: context.id,
     params: params as BottomSheetPortalParams<T>,
+    preventDismiss,
     close,
     forceClose,
     closeBottomSheet: close,


### PR DESCRIPTION
## What

Two related `preventDismiss` improvements:

### 1. Native gesture block (SwmansionSheetAdapter)
When a sheet sets `preventDismiss` (via `useOnBeforeClose`), the collapsed detent (index 0) is now marked as `programmatic`, so the Software Mansion native sheet **cannot be dragged down to dismiss**. `close()` / backdrop tap still collapse it via the controlled `index`.

Previously, `preventDismiss` only re-snapped the sheet up inside `onIndexChange` — that fires *after* the drag commits to the collapsed detent, so it didn't actually block the native pan-to-close gesture.

### 2. Expose `preventDismiss` from `useBottomSheetContext`
`useBottomSheetContext()` now returns `preventDismiss`, so UI can react to it (e.g. hide a grab handle when the sheet can't be swiped down) without reaching into the store.

## Why
Consumers wiring `useOnBeforeClose(() => false)` expected the swipe-down gesture to be blocked and the grab handle to disappear; neither happened.

## Notes
- `close()`, backdrop tap, and back button still work (they go through the controlled index / coordinator, not the blocked drag).
- No API break — `preventDismiss` is additive on the context return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)