### PR TITLE
docs: split built-in adapters into one page per adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ function YourAppContent() {
 
 Adapters with 3rd-party dependencies are shipped as separate subpath exports so that importing the main package never triggers Metro resolution errors for uninstalled libraries. Each sheet in the stack can use a different adapter.
 
-`SwmansionSheetAdapter` also adds a few opt-in conveniences over the bare native sheet (`handle`, `fullHeight`, `fillContent`, `keyboardBehavior`) — see [Shipped Adapters](https://github.com/arekkubaczkowski/react-native-bottom-sheet-stack/blob/main/docs/docs/built-in-adapters.md#convenience-props).
+`SwmansionSheetAdapter` also adds a few opt-in conveniences over the bare native sheet (`handle`, `fullHeight`, `fillContent`, `keyboardBehavior`, `cornerRadius`) — see [SwmansionSheetAdapter](https://github.com/arekkubaczkowski/react-native-bottom-sheet-stack/blob/main/docs/docs/built-in-adapters/swmansion.md#convenience-props).
 
 ## License
 

--- a/docs/docs/api/components.md
+++ b/docs/docs/api/components.md
@@ -66,11 +66,11 @@ Adapters with 3rd-party dependencies are shipped as separate subpath exports:
 
 | Adapter | Import | Library | Docs |
 |---------|--------|---------|------|
-| `GorhomSheetAdapter` | `react-native-bottom-sheet-stack/gorhom` | `@gorhom/bottom-sheet` | [Shipped Adapters](/built-in-adapters) |
-| `CustomModalAdapter` | `react-native-bottom-sheet-stack` | Custom Animated View | [Shipped Adapters](/built-in-adapters) |
-| `ReactNativeModalAdapter` | `react-native-bottom-sheet-stack/react-native-modal` | `react-native-modal` | [Shipped Adapters](/built-in-adapters) |
-| `ActionsSheetAdapter` | `react-native-bottom-sheet-stack/actions-sheet` | `react-native-actions-sheet` | [Shipped Adapters](/built-in-adapters) |
-| `SwmansionSheetAdapter` | `react-native-bottom-sheet-stack/swmansion` | `@swmansion/react-native-bottom-sheet` | [Shipped Adapters](/built-in-adapters) |
+| `GorhomSheetAdapter` | `react-native-bottom-sheet-stack/gorhom` | `@gorhom/bottom-sheet` | [GorhomSheetAdapter](/built-in-adapters/gorhom) |
+| `CustomModalAdapter` | `react-native-bottom-sheet-stack` | Custom Animated View | [CustomModalAdapter](/built-in-adapters/custom-modal) |
+| `ReactNativeModalAdapter` | `react-native-bottom-sheet-stack/react-native-modal` | `react-native-modal` | [ReactNativeModalAdapter](/built-in-adapters/react-native-modal) |
+| `ActionsSheetAdapter` | `react-native-bottom-sheet-stack/actions-sheet` | `react-native-actions-sheet` | [ActionsSheetAdapter](/built-in-adapters/actions-sheet) |
+| `SwmansionSheetAdapter` | `react-native-bottom-sheet-stack/swmansion` | `@swmansion/react-native-bottom-sheet` | [SwmansionSheetAdapter](/built-in-adapters/swmansion) |
 
 :::tip
 `BottomSheetManaged` is available as a deprecated re-export from `react-native-bottom-sheet-stack/gorhom` for backward compatibility.

--- a/docs/docs/built-in-adapters/actions-sheet.md
+++ b/docs/docs/built-in-adapters/actions-sheet.md
@@ -1,0 +1,38 @@
+# ActionsSheetAdapter
+
+Wraps [`react-native-actions-sheet`](https://github.com/ammarahm-ed/react-native-actions-sheet) — a zero-dependency action sheet with snap points, gestures, and a SheetManager API.
+
+## Installation
+
+```bash
+npm install react-native-actions-sheet
+```
+
+## Usage
+
+```tsx
+import { ActionsSheetAdapter } from 'react-native-bottom-sheet-stack/actions-sheet';
+
+function MyActionsSheet() {
+  const { close } = useBottomSheetContext();
+
+  return (
+    <ActionsSheetAdapter snapPoints={[50, 100]} gestureEnabled>
+      <View style={{ padding: 20 }}>
+        <Text>Actions sheet with snap points</Text>
+        <Button title="Close" onPress={close} />
+      </View>
+    </ActionsSheetAdapter>
+  );
+}
+```
+
+## Props
+
+All [`react-native-actions-sheet` props](https://github.com/ammarahm-ed/react-native-actions-sheet#actionsheet-props) are accepted via spread.
+
+Adapter defaults (overridable): `gestureEnabled`, `closeOnTouchBackdrop`, `closeOnPressBack`, `keyboardHandlerEnabled`.
+
+:::tip
+This adapter uses `isModal={false}` internally to avoid wrapping in a redundant Modal — the stack manager handles the overlay lifecycle.
+:::

--- a/docs/docs/built-in-adapters/custom-modal.md
+++ b/docs/docs/built-in-adapters/custom-modal.md
@@ -1,0 +1,42 @@
+# CustomModalAdapter
+
+Custom React Native dialog UI. No additional dependencies needed.
+
+## Usage
+
+```tsx
+import { CustomModalAdapter, useBottomSheetContext } from 'react-native-bottom-sheet-stack';
+
+function MyModal() {
+  const { close } = useBottomSheetContext();
+
+  return (
+    <CustomModalAdapter>
+      <View style={{ flex: 1, padding: 20 }}>
+        <Text>Modal content</Text>
+        <Button title="Close" onPress={close} />
+      </View>
+    </CustomModalAdapter>
+  );
+}
+```
+
+## Props
+
+Accepts `contentContainerStyle` for the inner wrapper view.
+
+## Mixed Stacking
+
+Modals and bottom sheets can coexist in the same stack:
+
+```tsx
+const { open } = useBottomSheetManager();
+const modalControl = useBottomSheetControl('my-modal');
+
+// Push a bottom sheet
+open(<MyBottomSheet />, { mode: 'push' });
+
+// Then push a modal on top
+modalControl.open({ mode: 'push' });
+// Both are in the stack — closing the modal returns to the bottom sheet
+```

--- a/docs/docs/built-in-adapters/gorhom.md
+++ b/docs/docs/built-in-adapters/gorhom.md
@@ -1,0 +1,57 @@
+# GorhomSheetAdapter
+
+The default adapter. Wraps `@gorhom/bottom-sheet` to provide feature-rich bottom sheets with snap points, spring animations, and swipe gestures.
+
+:::tip
+`BottomSheetManaged` is available as a deprecated re-export from the same subpath for backward compatibility.
+:::
+
+## Installation
+
+```bash
+npm install @gorhom/bottom-sheet react-native-reanimated react-native-gesture-handler
+```
+
+## Usage
+
+```tsx
+import { GorhomSheetAdapter } from 'react-native-bottom-sheet-stack/gorhom';
+import { BottomSheetView } from '@gorhom/bottom-sheet';
+
+const MySheet = forwardRef((props, ref) => {
+  const { close } = useBottomSheetContext();
+
+  return (
+    <GorhomSheetAdapter ref={ref} snapPoints={['50%', '90%']}>
+      <BottomSheetView>
+        <Text>Sheet content</Text>
+        <Button title="Close" onPress={close} />
+      </BottomSheetView>
+    </GorhomSheetAdapter>
+  );
+});
+```
+
+## Props
+
+Accepts all props from [`@gorhom/bottom-sheet`](https://gorhom.dev/react-native-bottom-sheet/props). The adapter overrides `enablePanDownToClose` to `true` by default.
+
+## Backdrop
+
+By default this adapter renders gorhom's `backdropComponent` as `null` so the **stack manager's shared backdrop** (`BottomSheetBackdrop`) is used instead. This is recommended — the manager's backdrop is **stack-aware** (correct opacity across stacked sheets, z-index, scale coordination, cascading tap-to-dismiss), which a per-sheet gorhom backdrop is not.
+
+You **can** override it by passing your own `backdropComponent`, but it's **not recommended** unless you specifically need gorhom's backdrop behavior. When you do, the adapter **automatically disables the manager backdrop** for that sheet so the two never stack:
+
+```tsx
+import { BottomSheetBackdrop as GorhomBackdrop } from '@gorhom/bottom-sheet';
+
+<GorhomSheetAdapter snapPoints={['50%']} backdropComponent={GorhomBackdrop}>
+  {/* ... */}
+</GorhomSheetAdapter>;
+```
+
+## When to Use
+
+- You need snap points, scrollable content, keyboard handling
+- You want the most feature-rich bottom sheet experience
+- Your app already uses `@gorhom/bottom-sheet`

--- a/docs/docs/built-in-adapters/index.md
+++ b/docs/docs/built-in-adapters/index.md
@@ -1,0 +1,18 @@
+---
+slug: /built-in-adapters
+sidebar_label: Overview
+---
+
+# Shipped Adapters
+
+All adapters listed below ship with the library. `CustomModalAdapter` requires no additional dependencies. The others wrap optional peer dependencies — install only what you use.
+
+| Adapter | Import | Wraps |
+| --- | --- | --- |
+| [GorhomSheetAdapter](./gorhom.md) | `react-native-bottom-sheet-stack/gorhom` | `@gorhom/bottom-sheet` |
+| [SwmansionSheetAdapter](./swmansion.md) | `react-native-bottom-sheet-stack/swmansion` | `@swmansion/react-native-bottom-sheet` (Fabric / New Arch) |
+| [CustomModalAdapter](./custom-modal.md) | `react-native-bottom-sheet-stack` | Custom animated view (zero deps) |
+| [ReactNativeModalAdapter](./react-native-modal.md) | `react-native-bottom-sheet-stack/react-native-modal` | `react-native-modal` |
+| [ActionsSheetAdapter](./actions-sheet.md) | `react-native-bottom-sheet-stack/actions-sheet` | `react-native-actions-sheet` |
+
+Each sheet in the stack can use a different adapter. See [Library-Agnostic Architecture](/adapters) for how adapters work, or [Building Custom Adapters](/custom-adapters) to create your own.

--- a/docs/docs/built-in-adapters/react-native-modal.md
+++ b/docs/docs/built-in-adapters/react-native-modal.md
@@ -1,0 +1,39 @@
+# ReactNativeModalAdapter
+
+Wraps [`react-native-modal`](https://github.com/react-native-modal/react-native-modal) — a feature-rich modal with 60+ animation options, swipe-to-dismiss, and customizable backdrops.
+
+## Installation
+
+```bash
+npm install react-native-modal
+```
+
+## Usage
+
+```tsx
+import { ReactNativeModalAdapter } from 'react-native-bottom-sheet-stack/react-native-modal';
+
+function FancyModal() {
+  const { close } = useBottomSheetContext();
+
+  return (
+    <ReactNativeModalAdapter
+      animationIn="slideInUp"
+      animationOut="slideOutDown"
+      swipeDirection="down"
+      backdropOpacity={0.6}
+    >
+      <View style={{ flex: 1, padding: 20 }}>
+        <Text>Fancy animated modal</Text>
+        <Button title="Close" onPress={close} />
+      </View>
+    </ReactNativeModalAdapter>
+  );
+}
+```
+
+## Props
+
+All [`react-native-modal` props](https://github.com/react-native-modal/react-native-modal#available-props) are accepted via spread.
+
+Adapter defaults (overridable): `swipeDirection="down"`, `backdropOpacity={0.5}`, `useNativeDriver`, `hideModalContentWhileAnimating`.

--- a/docs/docs/built-in-adapters/swmansion.md
+++ b/docs/docs/built-in-adapters/swmansion.md
@@ -1,200 +1,4 @@
----
-sidebar_position: 10
----
-
-# Shipped Adapters
-
-All adapters listed below ship with the library. `CustomModalAdapter` requires no additional dependencies. The others wrap optional peer dependencies — install only what you use.
-
-## GorhomSheetAdapter
-
-The default adapter. Wraps `@gorhom/bottom-sheet` to provide feature-rich bottom sheets with snap points, spring animations, and swipe gestures.
-
-:::tip
-`BottomSheetManaged` is available as a deprecated re-export from the same subpath for backward compatibility.
-:::
-
-### Installation
-
-```bash
-npm install @gorhom/bottom-sheet react-native-reanimated react-native-gesture-handler
-```
-
-### Usage
-
-```tsx
-import { GorhomSheetAdapter } from 'react-native-bottom-sheet-stack/gorhom';
-import { BottomSheetView } from '@gorhom/bottom-sheet';
-
-const MySheet = forwardRef((props, ref) => {
-  const { close } = useBottomSheetContext();
-
-  return (
-    <GorhomSheetAdapter ref={ref} snapPoints={['50%', '90%']}>
-      <BottomSheetView>
-        <Text>Sheet content</Text>
-        <Button title="Close" onPress={close} />
-      </BottomSheetView>
-    </GorhomSheetAdapter>
-  );
-});
-```
-
-### Props
-
-Accepts all props from [`@gorhom/bottom-sheet`](https://gorhom.dev/react-native-bottom-sheet/props). The adapter overrides `enablePanDownToClose` to `true` by default.
-
-### Backdrop
-
-By default this adapter renders gorhom's `backdropComponent` as `null` so the **stack manager's shared backdrop** (`BottomSheetBackdrop`) is used instead. This is recommended — the manager's backdrop is **stack-aware** (correct opacity across stacked sheets, z-index, scale coordination, cascading tap-to-dismiss), which a per-sheet gorhom backdrop is not.
-
-You **can** override it by passing your own `backdropComponent`, but it's **not recommended** unless you specifically need gorhom's backdrop behavior. When you do, the adapter **automatically disables the manager backdrop** for that sheet so the two never stack:
-
-```tsx
-import { BottomSheetBackdrop as GorhomBackdrop } from '@gorhom/bottom-sheet';
-
-<GorhomSheetAdapter snapPoints={['50%']} backdropComponent={GorhomBackdrop}>
-  {/* ... */}
-</GorhomSheetAdapter>;
-```
-
-### When to Use
-
-- You need snap points, scrollable content, keyboard handling
-- You want the most feature-rich bottom sheet experience
-- Your app already uses `@gorhom/bottom-sheet`
-
----
-
-## CustomModalAdapter
-
-Custom React Native dialog UI. No additional dependencies needed.
-
-### Usage
-
-```tsx
-import { CustomModalAdapter, useBottomSheetContext } from 'react-native-bottom-sheet-stack';
-
-function MyModal() {
-  const { close } = useBottomSheetContext();
-
-  return (
-    <CustomModalAdapter>
-      <View style={{ flex: 1, padding: 20 }}>
-        <Text>Modal content</Text>
-        <Button title="Close" onPress={close} />
-      </View>
-    </CustomModalAdapter>
-  );
-}
-```
-
-### Props
-
-Accepts `contentContainerStyle` for the inner wrapper view.
-
-### Mixed Stacking
-
-Modals and bottom sheets can coexist in the same stack:
-
-```tsx
-const { open } = useBottomSheetManager();
-const modalControl = useBottomSheetControl('my-modal');
-
-// Push a bottom sheet
-open(<MyBottomSheet />, { mode: 'push' });
-
-// Then push a modal on top
-modalControl.open({ mode: 'push' });
-// Both are in the stack — closing the modal returns to the bottom sheet
-```
-
----
-
-## ReactNativeModalAdapter
-
-Wraps [`react-native-modal`](https://github.com/react-native-modal/react-native-modal) — a feature-rich modal with 60+ animation options, swipe-to-dismiss, and customizable backdrops.
-
-### Installation
-
-```bash
-npm install react-native-modal
-```
-
-### Usage
-
-```tsx
-import { ReactNativeModalAdapter } from 'react-native-bottom-sheet-stack/react-native-modal';
-
-function FancyModal() {
-  const { close } = useBottomSheetContext();
-
-  return (
-    <ReactNativeModalAdapter
-      animationIn="slideInUp"
-      animationOut="slideOutDown"
-      swipeDirection="down"
-      backdropOpacity={0.6}
-    >
-      <View style={{ flex: 1, padding: 20 }}>
-        <Text>Fancy animated modal</Text>
-        <Button title="Close" onPress={close} />
-      </View>
-    </ReactNativeModalAdapter>
-  );
-}
-```
-
-### Props
-
-All [`react-native-modal` props](https://github.com/react-native-modal/react-native-modal#available-props) are accepted via spread.
-
-Adapter defaults (overridable): `swipeDirection="down"`, `backdropOpacity={0.5}`, `useNativeDriver`, `hideModalContentWhileAnimating`.
-
----
-
-## ActionsSheetAdapter
-
-Wraps [`react-native-actions-sheet`](https://github.com/ammarahm-ed/react-native-actions-sheet) — a zero-dependency action sheet with snap points, gestures, and a SheetManager API.
-
-### Installation
-
-```bash
-npm install react-native-actions-sheet
-```
-
-### Usage
-
-```tsx
-import { ActionsSheetAdapter } from 'react-native-bottom-sheet-stack/actions-sheet';
-
-function MyActionsSheet() {
-  const { close } = useBottomSheetContext();
-
-  return (
-    <ActionsSheetAdapter snapPoints={[50, 100]} gestureEnabled>
-      <View style={{ padding: 20 }}>
-        <Text>Actions sheet with snap points</Text>
-        <Button title="Close" onPress={close} />
-      </View>
-    </ActionsSheetAdapter>
-  );
-}
-```
-
-### Props
-
-All [`react-native-actions-sheet` props](https://github.com/ammarahm-ed/react-native-actions-sheet#actionsheet-props) are accepted via spread.
-
-Adapter defaults (overridable): `gestureEnabled`, `closeOnTouchBackdrop`, `closeOnPressBack`, `keyboardHandlerEnabled`.
-
-:::tip
-This adapter uses `isModal={false}` internally to avoid wrapping in a redundant Modal — the stack manager handles the overlay lifecycle.
-:::
-
----
-
-## SwmansionSheetAdapter
+# SwmansionSheetAdapter
 
 Wraps [`@swmansion/react-native-bottom-sheet`](https://github.com/software-mansion-labs/react-native-bottom-sheet) — Software Mansion's **fully native (Fabric)** bottom sheet driven by a `detents`/`index` model.
 
@@ -202,13 +6,13 @@ Wraps [`@swmansion/react-native-bottom-sheet`](https://github.com/software-mansi
 `@swmansion/react-native-bottom-sheet` is a Fabric native component. It requires the **New Architecture** (`react-native >= 0.76`) and a native build (it does **not** run in Expo Go — use a development build / `expo prebuild`).
 :::
 
-### Installation
+## Installation
 
 ```bash
 npm install @swmansion/react-native-bottom-sheet react-native-safe-area-context
 ```
 
-### Usage
+## Usage
 
 ```tsx
 import { SwmansionSheetAdapter } from 'react-native-bottom-sheet-stack/swmansion';
@@ -228,7 +32,7 @@ function MySheet() {
 }
 ```
 
-### The controlled → imperative bridge
+## The controlled → imperative bridge
 
 Software Mansion's sheet is **fully controlled**: it exposes no imperative ref, and its position is driven entirely by the `index` prop (a zero-based index into `detents`). The stack manager, on the other hand, drives sheets imperatively (`expand()` / `close()`). The adapter bridges the two:
 
@@ -244,7 +48,7 @@ Software Mansion's sheet is **fully controlled**: it exposes no imperative ref, 
 The detent at index `0` must resolve to `0` (collapsed) so the manager can close the sheet — this matches the library's default `detents` of `[0, 'content']`. A dev-mode warning fires if it doesn't.
 :::
 
-### Props
+## Props
 
 Accepts the full prop surface of [`@swmansion/react-native-bottom-sheet`](https://github.com/software-mansion-labs/react-native-bottom-sheet)'s `BottomSheet` (`detents`, `style`, `animateIn`, `scrimColor`, `disableScrollableNegotiation`, `onIndexChange`, `onSettle`, `onPositionChange`), **except** the props the manager owns:
 
@@ -253,7 +57,7 @@ Accepts the full prop surface of [`@swmansion/react-native-bottom-sheet`](https:
 
 Your `onIndexChange` / `onSettle` / `onPositionChange` handlers are still invoked after the adapter's own logic. The `programmatic()` helper plus the `Detent`, `DetentValue`, `SwmansionSheetAdapterProps` and `SwmansionHandleConfig` (the `handle` object form) types are exported from the subpath for convenience.
 
-### Convenience props
+## Convenience props
 
 The native sheet is intentionally minimal. The adapter layers a few **opt-in** conveniences on top of it — each defaults to off, so a bare `<SwmansionSheetAdapter>` behaves exactly like the raw native sheet. They are additive: nothing here changes the controlled `detents`/`index` model, and you can still drive everything by hand.
 
@@ -297,7 +101,7 @@ npm install react-native-keyboard-controller
 ```
 :::
 
-### Backdrop
+## Backdrop
 
 By default the sheet uses the **stack manager's shared backdrop** (`BottomSheetBackdrop`) and the native scrim is disabled (`scrimColor` defaults to `'transparent'`). This is almost always what you want — the manager's backdrop is **stack-aware**: it interpolates opacity correctly across stacked sheets, sits at the right z-index, coordinates with the background scale animation, and participates in cascading tap-to-dismiss.
 
@@ -311,11 +115,11 @@ You **can** opt into the native swmansion scrim by passing `scrimColor` / `scrim
 
 When you pass a scrim, the adapter **automatically disables the manager backdrop** for that sheet — so the two never stack into a double-dark overlay and you don't need to do anything else.
 
-### Android back button
+## Android back button
 
 This adapter registers a hardware-back handler automatically (via the internal `useBackHandler`): pressing Android back dismisses the top, fully-open sheet — the same contract the other adapters honor. You don't need to wire anything up yourself.
 
-### When to Use
+## When to Use
 
 - You want a fully native sheet built on the New Architecture
 - You prefer a controlled `detents`/`index` model

--- a/docs/docs/custom-adapters.md
+++ b/docs/docs/custom-adapters.md
@@ -246,7 +246,7 @@ const onIndexChange = (i: number) => {
 };
 ```
 
-This is exactly how [`SwmansionSheetAdapter`](/built-in-adapters#swmansionsheetadapter) bridges Software Mansion's native sheet. When the library also reports a continuous position (e.g. `onPositionChange`), interpolate it into `animatedIndex` (`[-1, 0]`) for a smooth backdrop fade.
+This is exactly how [`SwmansionSheetAdapter`](/built-in-adapters/swmansion) bridges Software Mansion's native sheet. When the library also reports a continuous position (e.g. `onPositionChange`), interpolate it into `animatedIndex` (`[-1, 0]`) for a smooth backdrop fade.
 
 ### Libraries Without Separate Dismiss/Close Phases
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -15,7 +15,23 @@ const sidebars: SidebarsConfig = {
       type: 'category',
       label: 'Adapters',
       collapsed: false,
-      items: ['adapters', 'built-in-adapters', 'custom-adapters'],
+      items: [
+        'adapters',
+        {
+          type: 'category',
+          label: 'Built-in Adapters',
+          collapsed: false,
+          link: { type: 'doc', id: 'built-in-adapters/index' },
+          items: [
+            'built-in-adapters/gorhom',
+            'built-in-adapters/swmansion',
+            'built-in-adapters/custom-modal',
+            'built-in-adapters/react-native-modal',
+            'built-in-adapters/actions-sheet',
+          ],
+        },
+        'custom-adapters',
+      ],
     },
     {
       type: 'category',


### PR DESCRIPTION
## What

Splits the single **Shipped Adapters** page into one page per adapter, each shown in the sidebar under a **Built-in Adapters** category for easier reference/navigation.

```
Adapters
├─ Library-Agnostic Architecture
├─ Built-in Adapters            ← category (landing = overview, /built-in-adapters)
│  ├─ GorhomSheetAdapter
│  ├─ SwmansionSheetAdapter
│  ├─ CustomModalAdapter
│  ├─ ReactNativeModalAdapter
│  └─ ActionsSheetAdapter
└─ Building Custom Adapters
```

## Details

- New folder `docs/docs/built-in-adapters/` with `index.md` (overview, keeps the `/built-in-adapters` slug) + one page per adapter.
- Sidebar: nested **Built-in Adapters** category with `link` to the overview.
- Internal links updated: `custom-adapters.md` → `/built-in-adapters/swmansion`; `api/components.md` "Docs" column → per-adapter pages; `README.md` convenience-props deep link → `built-in-adapters/swmansion.md`.
- Content unchanged otherwise (per-adapter `##` headings normalized).

## Validation

`docusaurus build` passes (no broken links/anchors; `onBrokenLinks: throw`). lint + types pre-commit hooks pass.