### PR TITLE
fix(adapters): recover gorhom from dropped onChange; drop dead swmansion settle guard

### DIFF
--- a/example/src/sheets/ScannerSheet.tsx
+++ b/example/src/sheets/ScannerSheet.tsx
@@ -1,4 +1,3 @@
-import type { BottomSheetMethods } from '@gorhom/bottom-sheet/lib/typescript/types';
 import { forwardRef, useCallback, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import {
@@ -6,11 +5,13 @@ import {
   useBottomSheetManager,
 } from 'react-native-bottom-sheet-stack';
 
-import { Badge, Button, SecondaryButton, Sheet } from '../components';
+import type { SheetAdapterRef } from '../../../src/adapter.types';
+import { SwmansionSheetAdapter } from '../../../src/adapters/swmansion';
+import { Badge, Button, SecondaryButton } from '../components';
 import { ScannerNestedSheet1 } from './ScannerNestedSheets';
 import { colors, sharedStyles } from '../styles/theme';
 
-export const ScannerSheet = forwardRef<BottomSheetMethods>((_, ref) => {
+export const ScannerSheet = forwardRef<SheetAdapterRef>((_, ref) => {
   const { close, params } = useBottomSheetContext<'scanner-sheet'>();
   const { open } = useBottomSheetManager();
   const [isScanning, setIsScanning] = useState(false);
@@ -39,92 +40,101 @@ export const ScannerSheet = forwardRef<BottomSheetMethods>((_, ref) => {
   }, []);
 
   return (
-    <Sheet ref={ref} enableDynamicSizing>
-      <View style={styles.badgeRow}>
-        <Badge label="Persistent" color={colors.cyan} />
-        <Badge
-          label={sourceLabel}
-          color={
-            params?.source === 'navigation' ? colors.purple : colors.primary
-          }
-        />
-      </View>
-      <Text style={sharedStyles.h1}>{title}</Text>
-      <Text style={sharedStyles.text}>
-        This sheet is always mounted (keepMounted). It opens instantly without
-        mount delay and preserves state between open/close cycles.
-      </Text>
-
-      {/* Scanner viewport */}
-      <View style={styles.scannerViewport}>
-        {isScanning ? (
-          <View style={styles.scanningOverlay}>
-            <View style={styles.scanLine} />
-            <Text style={styles.scanningText}>Scanning...</Text>
-          </View>
-        ) : scanResult ? (
-          <View style={styles.resultContainer}>
-            <Text style={styles.resultLabel}>Scanned Code:</Text>
-            <Text style={styles.resultValue}>{scanResult}</Text>
-          </View>
-        ) : (
-          <View style={styles.placeholderContainer}>
-            <Text style={styles.placeholderIcon}>[ ]</Text>
-            <Text style={styles.placeholderText}>Ready to scan</Text>
-          </View>
-        )}
-      </View>
-
-      {/* Actions */}
-      <View style={styles.actions}>
-        {scanResult ? (
-          <>
-            <Button title="Scan Again" onPress={handleReset} />
-            <Button
-              title="Open Nested Sheet"
-              onPress={() =>
-                open(<ScannerNestedSheet1 />, {
-                  scaleBackground: true,
-                  mode: 'switch',
-                })
-              }
-            />
-            <SecondaryButton title="Close" onPress={close} />
-          </>
-        ) : (
-          <>
-            <Button
-              title={isScanning ? 'Scanning...' : 'Start Scan'}
-              onPress={isScanning ? () => {} : handleStartScan}
-            />
-            <Button
-              title="Open Nested Sheet"
-              onPress={() =>
-                open(<ScannerNestedSheet1 />, {
-                  scaleBackground: true,
-                  mode: 'switch',
-                })
-              }
-            />
-            <SecondaryButton title="Close" onPress={close} />
-          </>
-        )}
-      </View>
-
-      {/* Info box */}
-      <View style={styles.infoBox}>
-        <Text style={styles.infoText}>
-          Try closing and reopening - the sheet appears instantly because it's
-          pre-mounted with keepMounted flag.
+    <SwmansionSheetAdapter ref={ref} detents={[0, 'content']} handle>
+      <View style={styles.content}>
+        <View style={styles.badgeRow}>
+          <Badge label="Persistent" color={colors.cyan} />
+          <Badge
+            label={sourceLabel}
+            color={
+              params?.source === 'navigation' ? colors.purple : colors.primary
+            }
+          />
+        </View>
+        <Text style={sharedStyles.h1}>{title}</Text>
+        <Text style={sharedStyles.text}>
+          This sheet is always mounted (keepMounted). It opens instantly without
+          mount delay and preserves state between open/close cycles.
         </Text>
+
+        {/* Scanner viewport */}
+        <View style={styles.scannerViewport}>
+          {isScanning ? (
+            <View style={styles.scanningOverlay}>
+              <View style={styles.scanLine} />
+              <Text style={styles.scanningText}>Scanning...</Text>
+            </View>
+          ) : scanResult ? (
+            <View style={styles.resultContainer}>
+              <Text style={styles.resultLabel}>Scanned Code:</Text>
+              <Text style={styles.resultValue}>{scanResult}</Text>
+            </View>
+          ) : (
+            <View style={styles.placeholderContainer}>
+              <Text style={styles.placeholderIcon}>[ ]</Text>
+              <Text style={styles.placeholderText}>Ready to scan</Text>
+            </View>
+          )}
+        </View>
+
+        {/* Actions */}
+        <View style={styles.actions}>
+          {scanResult ? (
+            <>
+              <Button title="Scan Again" onPress={handleReset} />
+              <Button
+                title="Open Nested Sheet"
+                onPress={() =>
+                  open(<ScannerNestedSheet1 />, {
+                    scaleBackground: true,
+                    mode: 'switch',
+                  })
+                }
+              />
+              <SecondaryButton title="Close" onPress={close} />
+            </>
+          ) : (
+            <>
+              <Button
+                title={isScanning ? 'Scanning...' : 'Start Scan'}
+                onPress={isScanning ? () => {} : handleStartScan}
+              />
+              <Button
+                title="Open Nested Sheet"
+                onPress={() =>
+                  open(<ScannerNestedSheet1 />, {
+                    scaleBackground: true,
+                    mode: 'switch',
+                  })
+                }
+              />
+              <SecondaryButton title="Close" onPress={close} />
+            </>
+          )}
+        </View>
+
+        {/* Info box */}
+        <View style={styles.infoBox}>
+          <Text style={styles.infoText}>
+            Try closing and reopening - the sheet appears instantly because it's
+            pre-mounted with keepMounted flag.
+          </Text>
+        </View>
       </View>
-    </Sheet>
+    </SwmansionSheetAdapter>
   );
 });
 
 ScannerSheet.displayName = 'ScannerSheet';
 
 const styles = StyleSheet.create({
+  content: {
+    backgroundColor: colors.surface,
+    paddingHorizontal: 20,
+    paddingTop: 8,
+    paddingBottom: 32,
+    gap: 8,
+  },
   badgeRow: {
     flexDirection: 'row',
     gap: 8,

--- a/src/adapters/gorhom-sheet/GorhomSheetAdapter.tsx
+++ b/src/adapters/gorhom-sheet/GorhomSheetAdapter.tsx
@@ -5,6 +5,7 @@ import BottomSheetOriginal, {
 import type { BottomSheetMethods } from '@gorhom/bottom-sheet/lib/typescript/types';
 import React, { useEffect, useImperativeHandle, useRef } from 'react';
 import { useAnimatedReaction } from 'react-native-reanimated';
+import { scheduleOnRN } from 'react-native-worklets';
 
 import type { SheetAdapterRef } from '../../adapter.types';
 import {
@@ -57,6 +58,9 @@ export const GorhomSheetAdapter = React.forwardRef<
       return () => setBackdrop(id, true);
     }, [id, usesCustomBackdrop, setBackdrop]);
 
+    const { handleDismiss, handleOpened, handleClosed } =
+      createSheetEventHandlers(id);
+
     useImperativeHandle(
       ref,
       () => ({
@@ -68,13 +72,17 @@ export const GorhomSheetAdapter = React.forwardRef<
 
     useAnimatedReaction(
       () => contextAnimatedIndex.value,
-      (value) => {
+      (value, prev) => {
         externalAnimatedIndex?.set(value);
+        // gorhom can drop its onChange under rapid open/close interruptions
+        // (e.g. switch then immediate dismiss), leaving the sheet stuck mid-open.
+        // The animated index is the reliable signal: report opened when it
+        // crosses into an open snap point (idempotent via the status guard).
+        if (typeof prev === 'number' && prev < 0 && value >= 0) {
+          scheduleOnRN(handleOpened);
+        }
       }
     );
-
-    const { handleDismiss, handleOpened, handleClosed } =
-      createSheetEventHandlers(id);
 
     useBackHandler(id, handleDismiss);
 
@@ -96,7 +104,6 @@ export const GorhomSheetAdapter = React.forwardRef<
       position,
       type
     ) => {
-      // index >= 0 means sheet reached a valid snap point (opened)
       if (index >= 0) {
         handleOpened();
       }

--- a/src/adapters/swmansion/SwmansionSheetAdapter.tsx
+++ b/src/adapters/swmansion/SwmansionSheetAdapter.tsx
@@ -4,7 +4,6 @@ import React, {
   type ReactNode,
   useEffect,
   useImperativeHandle,
-  useRef,
   useState,
 } from 'react';
 import {
@@ -356,9 +355,6 @@ export const SwmansionSheetAdapter = React.forwardRef<
       );
     }
 
-    // Guards against reporting the initial collapsed-detent settle as a close.
-    const hasOpenedRef = useRef(false);
-
     useImperativeHandle(
       ref,
       () => ({
@@ -370,11 +366,8 @@ export const SwmansionSheetAdapter = React.forwardRef<
 
     const handleNativeSettle = (settledIndex: number) => {
       if (settledIndex <= 0) {
-        if (hasOpenedRef.current) {
-          handleClosed();
-        }
+        handleClosed();
       } else {
-        hasOpenedRef.current = true;
         handleOpened();
       }
       onSettle?.(settledIndex);


### PR DESCRIPTION
## Two open/close lifecycle race fixes in the adapters

### gorhom — sheet stuck in `'opening'`, all opens blocked

**Repro:** open a sheet, tap **switch**, then immediately dismiss (backdrop/gesture) before it finishes opening → afterwards `push` / `switch` / `replace` do nothing (app responsive, buttons dead).

**Cause:** `switch` sets the sheet below to `'hidden'` and starts closing it. Dismissing the new top re-reveals the below sheet (`'hidden' → 'opening'`) and calls `expand()` while its close animation is still in flight. gorhom **swallows that `expand()` and never emits `onChange`** — the only signal that drove `handleOpened`. The sheet stays `'opening'` forever, which permanently trips the `hasOpeningInGroup` guard in `open()`, so every subsequent open is a no-op.

**Fix:** report opened from the **animated index** (a reliable signal gorhom keeps updating even when it drops the JS callback) via a `useAnimatedReaction` — fire `handleOpened` when the index crosses into an open snap point. Idempotent (the coordinator's `markOpen` only acts while `'opening'`). The existing `onChange → handleOpened` path is untouched; this is an additive backstop. Uses `scheduleOnRN` (not the deprecated `runOnJS`).

### swmansion — drop the now-dead settle guard

`onSettle` is now **optimistic** (fires when the animation *starts*), so a settle at the collapsed detent only ever follows a real close — the old `closeRequestedRef` / `hasOpenedRef` guard against a spurious pre-open `settle(0)` no longer fires. Verified empirically (including the `defaultIndex < 0` / persistent path): open emits `settle(openIndex)`, close emits `settle(0)`, and a mount-time `settle(0)` (if any) is absorbed by the coordinator's `status !== 'hidden'` check. The guard is removed; the settle is handled directly.

### example

`ScannerSheet` (a persistent sheet) now uses the swmansion adapter, adding coverage for the swmansion + persistent (`defaultIndex < 0`) combination that previously had none.

No changes to the shared store / coordinator.