### PR TITLE
fix: pre-compile worklets in build to prevent NativeWorklets copy crash

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -8,5 +8,8 @@ module.exports = {
         panicThreshold: 'all_errors',
       },
     ],
+    // Pre-compile worklets so shipped CJS doesn't crash consumers with
+    // "Cannot copy value of type NativeWorklets". Must run last.
+    'react-native-worklets/plugin',
   ],
 };


### PR DESCRIPTION
Adapters (GorhomSheetAdapter, CustomModalAdapter) call worklets APIs such
as `scheduleOnRN` inside worklets via named imports from
`react-native-worklets`. The library ships precompiled CommonJS, where bob
turned those named imports into namespace member access
(`_reactNativeWorklets.scheduleOnRN`). When a consumer app's worklets Babel
plugin re-processes that already-compiled worklet, it can't recognize the
member access as a hoistable global, so it captures the entire
`_reactNativeWorklets` namespace object — including the native
`NativeWorklets` singleton — into the worklet closure. Serializing that
closure to the UI thread crashes with:

  [Worklets] Cannot copy value of type NativeWorklets.

Add `react-native-worklets/plugin` to the library's own Babel build (after
react-compiler, so it runs last). The plugin now transforms worklets at
build time: it resolves the named import to just the serializable
`scheduleOnRN` function in the closure and stamps `__workletHash`, so the
consumer's plugin skips re-processing entirely. No consumer-side config
change required.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01J3Nqm7ZRJu2kN6JgXX4Dw2