### PR TITLE
chore: fix issue reporting flow (feature request template, drop dead Discussions links)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,1 @@
-blank_issues_enabled: false
-contact_links:
-  - name: Feature Request 💡
-    url: https://github.com/arekkubaczkowski/react-native-bottom-sheet-stack/discussions/new?category=ideas
-    about: If you have a feature request, please create a new discussion on GitHub.
-  - name: Discussions on GitHub 💬
-    url: https://github.com/arekkubaczkowski/react-native-bottom-sheet-stack/discussions
-    about: If this library works as promised but you need help, please ask questions there.
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,54 @@
+name: 💡 Feature request
+description: Suggest a new feature or improvement for this library.
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Feature request
+
+        👋 Hi, and thanks for taking the time to suggest an improvement!
+
+        **Please fill the following carefully before opening a new request ❗**
+        *(Keep in mind this library is a stack manager for bottom sheets/modals — not a single-sheet component — so please frame requests around that model.)*
+  - type: checkboxes
+    attributes:
+      label: Before submitting a new request
+      description: Please perform simple checks first.
+      options:
+        - label: I checked for possible duplicate requests, with possible answers.
+          required: true
+        - label: I read the README and confirmed this feature does not already exist.
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: |
+        Describe the use case and the limitation you are hitting.
+        Focus on the problem rather than a specific solution.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: |
+        Describe the API or behavior you would like to see.
+        If needed, provide code samples of how you would expect to use it.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe any alternative solutions or workarounds you have tried.
+    validations:
+      required: false
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context, screenshots, or references about the request here.
+    validations:
+      required: false


### PR DESCRIPTION
Issues were enabled on the repo but blank_issues_enabled was false and the
only Feature Request / help paths were contact_links pointing to Discussions,
which are not enabled — so those links 404'd and users could not file feature
requests or questions.

- Add feature_request.yml so feature requests become real issues
- Set blank_issues_enabled: true as a fallback
- Remove contact_links to the disabled Discussions

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019FuZy2LZCiLKEAb1brn2fv