### PR TITLE
fix: stop pre-compiling worklets, ship an ESM build instead (#37)

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -8,8 +8,18 @@ module.exports = {
         panicThreshold: 'all_errors',
       },
     ],
-    // Pre-compile worklets so shipped CJS doesn't crash consumers with
-    // "Cannot copy value of type NativeWorklets". Must run last.
-    'react-native-worklets/plugin',
+    // NOTE: We intentionally do NOT run 'react-native-worklets/plugin' here.
+    // Pre-compiling worklets in a published library bakes the plugin version
+    // into the shipped code (`__pluginVersion`), which then mismatches any
+    // consumer whose react-native-worklets version differs, crashing with
+    // "Mismatch between JavaScript code version and Worklets Babel plugin
+    // version" (see issue #37). Per Software Mansion's guidance, libraries must
+    // ship un-transpiled worklets and let the consuming app's Babel plugin
+    // transform them. To also avoid the namespace-capture crash that pre-
+    // compilation was papering over (issue #34 — CJS turns named worklets
+    // imports into `_reactNativeWorklets.x` member access that the consumer's
+    // plugin captures wholesale), we ship an ESM `module` build (see the
+    // react-native-builder-bob `targets` in package.json) that preserves named
+    // imports so the consumer's plugin hoists them correctly.
   ],
 };

--- a/package.json
+++ b/package.json
@@ -4,33 +4,41 @@
   "description": "Bottom Sheet Stack Manager",
   "source": "./src/index.tsx",
   "main": "lib/commonjs/index.js",
+  "module": "lib/module/index.js",
+  "react-native": "lib/module/index.js",
   "types": "lib/typescript/src/index.d.ts",
   "exports": {
     ".": {
       "types": "./lib/typescript/src/index.d.ts",
+      "react-native": "./lib/module/index.js",
       "default": "./lib/commonjs/index.js"
     },
     "./gorhom": {
       "types": "./lib/typescript/src/adapters/gorhom-sheet/index.d.ts",
+      "react-native": "./lib/module/adapters/gorhom-sheet/index.js",
       "default": "./lib/commonjs/adapters/gorhom-sheet/index.js"
     },
     "./react-native-modal": {
       "types": "./lib/typescript/src/adapters/react-native-modal/index.d.ts",
+      "react-native": "./lib/module/adapters/react-native-modal/index.js",
       "default": "./lib/commonjs/adapters/react-native-modal/index.js"
     },
     "./actions-sheet": {
       "types": "./lib/typescript/src/adapters/actions-sheet/index.d.ts",
+      "react-native": "./lib/module/adapters/actions-sheet/index.js",
       "default": "./lib/commonjs/adapters/actions-sheet/index.js"
     },
     "./swmansion": {
       "types": "./lib/typescript/src/adapters/swmansion/index.d.ts",
+      "react-native": "./lib/module/adapters/swmansion/index.js",
       "default": "./lib/commonjs/adapters/swmansion/index.js"
     }
   },
   "files": [
     "src",
     "lib/typescript",
-    "lib/commonjs"
+    "lib/commonjs",
+    "lib/module"
   ],
   "scripts": {
     "example": "yarn workspace react-native-bottom-sheet-stack-example",
@@ -187,6 +195,12 @@
     "source": "src",
     "output": "lib",
     "targets": [
+      [
+        "module",
+        {
+          "configFile": true
+        }
+      ],
       [
         "commonjs",
         {


### PR DESCRIPTION
Fixes #37

## What's broken

After upgrading to `1.18.3`, anyone whose `react-native-worklets` version doesn't exactly match the one this library was built with gets a hard crash:

```
[Worklets] Mismatch between JavaScript code version and Worklets Babel plugin version (0.7.4 vs. 0.7.1).
```

## Why it happens

In #34 we added `react-native-worklets/plugin` to the library's **own** Babel build to work around a "Cannot copy value of type NativeWorklets" crash. The side effect is that pre-compiling worklets stamps the plugin's version straight into the published files (`__pluginVersion = "0.7.1"`). At runtime, `react-native-worklets` compares that stamp against the version the app actually has installed — and if they differ (e.g. the app is on `0.7.4`), it throws.

The catch is that a library can never win this way: whatever version we build with gets frozen into the output, so every consumer on a different version breaks. Software Mansion's own guidance is explicit about this — **libraries should not pre-transpile worklets**. The app's Babel plugin has to be the one that transforms them, so the version always lines up.

## The fix

Two changes that work together:

1. **Remove `react-native-worklets/plugin` from `babel.config.js`.** Worklets ship un-transpiled, no version stamp, so there's nothing left to mismatch.

2. **Ship an ESM (`module`) build alongside CommonJS**, and point React Native at it via the `react-native` export condition.

The second part is what keeps #34 fixed without pre-compiling. The original crash came from CommonJS turning `import { scheduleOnRN } from 'react-native-worklets'` into `_reactNativeWorklets.scheduleOnRN` member access — when the app's plugin later re-processed that worklet, it couldn't tell the member access was safe and captured the entire `_reactNativeWorklets` namespace (native `NativeWorklets` singleton included), which can't be sent to the UI thread. An ESM build keeps the import as a plain named binding (`scheduleOnRN`), so the app's plugin hoists it cleanly and the namespace is never captured.

This is exactly how `@gorhom/bottom-sheet` — the library this one wraps — ships its own worklets: un-transpiled in `lib/module`, transformed by the consumer.

## How resolution works for consumers

```jsonc
"exports": {
  ".": {
    "react-native": "./lib/module/index.js",  // Metro → un-transpiled ESM, app transforms worklets
    "default":      "./lib/commonjs/index.js"  // Node / tooling → CommonJS
  }
}
```

React Native apps resolve the `react-native` condition and get the ESM build, so their Babel plugin transforms the worklets with the correct version. Node and other tooling fall back to CommonJS (they never run worklets anyway). Subpath adapter exports (`/gorhom`, `/swmansion`, …) get the same treatment.

## Changes

- `babel.config.js` — drop the worklets plugin from the build (with a comment explaining why, so it doesn't get re-added).
- `package.json` — add the `module` builder-bob target, `module` / `react-native` fields, `react-native` export conditions for every entry point, and `lib/module` to `files`.

No API changes and nothing for consumers to configure — the fix lands just by upgrading.

## Testing

- `yarn typecheck`, `yarn lint`, and `yarn prepare` (full build) all pass.
- Verified the generated `lib/module/**` output: worklets keep their `'worklet'` directives, named imports are preserved, and there are **no** `__pluginVersion` / `__workletHash` stamps anywhere.
- Confirmed CommonJS remains available as the `default` fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY3PEzjvuj5hrdNpAWHhkj